### PR TITLE
Instead of using an extension testgroup, run all extension tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,4 +15,3 @@ jobs:
           php: 7.4
           mwbranch: REL1_35
           extension: DummyExtension
-          testgroup: extension-DummyExtension

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,5 +13,5 @@ jobs:
         id: extension-test
         with:
           php: 7.4
-          mwbranch: REL1_35
+          mwbranch: REL1_39
           extension: DummyExtension

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ PHPUnit tests for your extension or skin repo:
     php: 7.4
     mwbranch: REL1_35
     extension: DummyExtension
-    testgroup: extension-DummyExtension
 ```
 
 # Inputs
@@ -24,7 +23,6 @@ PHPUnit tests for your extension or skin repo:
 * `php` - version of PHP to install
 * `mwbranch` - MediaWiki branch to install
 * `extension` - extension name to test (this should match the desired extension directory)
-* `testgroup` - @group of tests to run (this should match your extension group defined on unit tests)
 * `type` - (optional) either can be `extension` or `skin`, default value is `extension`
 
 # Example
@@ -69,7 +67,6 @@ jobs:
           php: ${{ matrix.php }}
           mwbranch: ${{ matrix.mw }}
           extension: MyExtension
-          testgroup: extension-MyExtension
 ```
 
 Example of adding a group to your extension tests:

--- a/action.yml
+++ b/action.yml
@@ -14,9 +14,6 @@ inputs:
   extension:
     description: 'Extension name to test'
     required: true
-  testgroup:
-    description: 'Extension tests @group'
-    required: true
   type:
     description: 'Is it an extension or skin'
     required: false
@@ -57,5 +54,5 @@ runs:
 
     - name: Run PHPUnit
       working-directory: mediawiki
-      run: php tests/phpunit/phpunit.php --group ${{ inputs.testgroup }}
+      run: php tests/phpunit/phpunit.php --testsuite extensions --exclude-group Broken,ParserFuzz,Stub
       shell: bash

--- a/tests/parser/tests.txt
+++ b/tests/parser/tests.txt
@@ -10,5 +10,6 @@ parsoid={ "modes": ["wt2html","wt2wt"], "normalizePhp": true }
 !! wikitext
 Foo ''bar''
 !! html
-<p>Foo <i>bar</i></p>
+<p>Foo <i>bar</i>
+</p>
 !! end

--- a/tests/parser/tests.txt
+++ b/tests/parser/tests.txt
@@ -1,0 +1,15 @@
+!! options
+version=2
+parsoid-compatible
+!! end
+
+!! test
+Simple
+!! options
+parsoid={ "modes": ["wt2html","wt2wt"], "normalizePhp": true }
+!! wikitext
+Foo ''bar''
+!! html
+<p>Foo <i>bar</i></p>
+!! end
+

--- a/tests/parser/tests.txt
+++ b/tests/parser/tests.txt
@@ -12,4 +12,3 @@ Foo ''bar''
 !! html
 <p>Foo <i>bar</i></p>
 !! end
-

--- a/tests/phpunit/DummyExtensionTest.php
+++ b/tests/phpunit/DummyExtensionTest.php
@@ -4,7 +4,6 @@ use DummyExtension\DummyExtension;
 
 /**
  * Class DummyExtensionTest
- * @group extension-DummyExtension
  */
 class DummyExtensionTest extends MediaWikiLangTestCase {
 


### PR DESCRIPTION
This remove the testgroup option

This ensures that parser tests, structure tests and less tests are also run for the extension.

Note: tests outside of phpunit (phan, composer test, npm test) will continue not to be run.