### PR TITLE
Add ability to load MediaWiki git submodules

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,10 @@ inputs:
     description: 'Is it an extension or skin'
     required: false
     default: 'extension'
+  loadsubmodules:
+    description: 'Whether to load MediaWiki git submodules (`yes` to enable)'
+    required: false
+    default: 'no'
 runs:
   using: 'composite'
   steps:
@@ -35,7 +39,7 @@ runs:
         key: composer-php${{ inputs.php }}
 
     - name: Install MediaWiki
-      run: bash $GITHUB_ACTION_PATH/install.sh ${{ inputs.mwbranch }} ${{ inputs.extension }} ${{ inputs.type }}
+      run: bash $GITHUB_ACTION_PATH/install.sh ${{ inputs.mwbranch }} ${{ inputs.extension }} ${{ inputs.type }} ${{ inputs.loadsubmodules }}
       shell: bash
 
     - uses: actions/checkout@v2

--- a/install.sh
+++ b/install.sh
@@ -5,6 +5,7 @@ set -o pipefail
 MW_BRANCH=$1
 EXTENSION_NAME=$2
 TYPE=$3
+LOAD_SUBMODULES=$4
 
 # Download wiki release
 wget https://github.com/wikimedia/mediawiki/archive/$MW_BRANCH.tar.gz -nv -q
@@ -15,6 +16,12 @@ mv mediawiki-$MW_BRANCH mediawiki
 
 # Install composer dependencies
 cd mediawiki && composer install
+
+# Only load submodules if requested
+if [ "$LOAD_SUBMODULES" = "yes" ]; then
+    git submodule update --init --recursive
+fi
+
 php maintenance/install.php \
   --dbtype sqlite \
   --dbuser root \


### PR DESCRIPTION
Needed to ensure that the `Vector` skin is available for testing the PerPageLanguage extension.

WIK-1013