### PR TITLE
README: update test example

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Example of adding a group to your extension tests:
 /**
  * @group extension-MyExtension
  */
-class MyExtensionTest extends MediaWikiTestCase {
+class MyExtensionTest extends MediaWikiIntegrationTestCase {
     // ...
 }
 ```


### PR DESCRIPTION
Use the `MediaWikiIntegrationTestCase` class, the alias `MediaWikiTestCase` was removed in 1.38

WIK-1400