### PR TITLE
Use git to install MediaWiki

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -34,8 +34,15 @@ runs:
         path: ~/.composer/cache
         key: composer-php${{ inputs.php }}
 
+    - name: Download Mediawiki
+      uses: actions/checkout@v2
+      with:
+        path: mediawiki
+        repository: wikimedia/mediawiki
+        ref: ${{ inputs.mwbranch }}
+
     - name: Install MediaWiki
-      run: bash $GITHUB_ACTION_PATH/install.sh ${{ inputs.mwbranch }} ${{ inputs.extension }} ${{ inputs.type }}
+      run: bash $GITHUB_ACTION_PATH/install.sh ${{ inputs.extension }} ${{ inputs.type }}
       shell: bash
 
     - uses: actions/checkout@v2

--- a/install.sh
+++ b/install.sh
@@ -2,16 +2,8 @@
 
 set -o pipefail
 
-MW_BRANCH=$1
-EXTENSION_NAME=$2
-TYPE=$3
-
-# Download wiki release
-wget https://github.com/wikimedia/mediawiki/archive/$MW_BRANCH.tar.gz -nv -q
-
-# Extract into `mediawiki` directory
-tar -zxf $MW_BRANCH.tar.gz
-mv mediawiki-$MW_BRANCH mediawiki
+EXTENSION_NAME=$1
+TYPE=$2
 
 # Install composer dependencies
 cd mediawiki && composer install


### PR DESCRIPTION
Rather than downloading and extracting the release file, use git (via the `actions/checkout@v2` GitHub action) to install MediaWiki. By default this will not include the history of the repo (no change from prior download method) but will include files that MediaWiki specifies should not be exported (change from prior download method that motivates this).

SEL-558