### PR TITLE
Allow extensions to choose database type

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,9 +1,9 @@
 on: [push]
 
 jobs:
-  mediawiki-extension-action:
+  mediawiki-extension-action-sqlite:
     runs-on: ubuntu-latest
-    name: Dummy extension test
+    name: Dummy extension test (sqlite)
     steps:
       # check out the repository
       - name: Checkout
@@ -15,3 +15,19 @@ jobs:
           php: 7.4
           mwbranch: REL1_39
           extension: DummyExtension
+
+  mediawiki-extension-action-mysql:
+    runs-on: ubuntu-latest
+    name: Dummy extension test (mysql)
+    steps:
+      # check out the repository
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Test dummy extension
+        uses: ./ # Uses an action in the root directory
+        id: extension-test
+        with:
+          php: 7.4
+          mwbranch: REL1_39
+          extension: DummyExtension
+          use_mysql: true

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ PHPUnit tests for your extension or skin repo:
 * `mwbranch` - MediaWiki branch to install
 * `extension` - extension name to test (this should match the desired extension directory)
 * `type` - (optional) either can be `extension` or `skin`, default value is `extension`
+* `use_mysql` - (optional) whether to use MySQL instead of SQLite
 
 # Example
 

--- a/action.yml
+++ b/action.yml
@@ -22,15 +22,22 @@ inputs:
     description: 'Path relative to the extension for a PHP file to load in settings'
     required: false
     default: ''
+  use_mysql:
+    description: Use MySQL instead of SQLite
+    required: false
+    default: false
 runs:
   using: 'composite'
   steps:
+
     - name: Install PHP
       uses: shivammathur/setup-php@v2
       with:
         php-version: ${{ inputs.php }}
-        extensions: mbstring, intl
+        extensions: ${{ env.PHP_EXTENSIONS }}
         tools: composer:2.1.14
+      env:
+        PHP_EXTENSIONS: ${{ inputs.use_mysql && 'mbstring, intl, mysqli' || 'mbstring, intl' }}
 
     - name: Add Composer cache
       uses: actions/cache@v2
@@ -46,7 +53,7 @@ runs:
         ref: ${{ inputs.mwbranch }}
 
     - name: Install MediaWiki
-      run: bash $GITHUB_ACTION_PATH/install.sh ${{ inputs.extension }} ${{ inputs.type }} ${{ inputs.extra_file }}
+      run: bash $GITHUB_ACTION_PATH/install.sh ${{ inputs.extension }} ${{ inputs.type }} ${{ inputs.use_mysql }} ${{ inputs.extra_file }}
       shell: bash
 
     - uses: actions/checkout@v2

--- a/install.sh
+++ b/install.sh
@@ -4,12 +4,27 @@ set -o pipefail
 
 EXTENSION_NAME=$1
 TYPE=$2
-EXTRA_INCLUDE_FILE=$3
+USE_MYSQL=$3
+EXTRA_INCLUDE_FILE=$4
+
+if [ "$USE_MYSQL" = "true" ]; then
+  DB_TYPE="mysql"
+  DB_SERVER="127.0.0.1"
+  # We need to start MySQL, but not sqlite
+  sudo systemctl start mysql
+else
+  DB_TYPE="sqlite"
+  DB_SERVER="localhost"
+fi
 
 # Install composer dependencies
 cd mediawiki && composer install
+
+# We can have --dbpass with 'root' for MySQL without breaking SQLite since
+# the SQLite installer just clears that, it doesn't use a password
 php maintenance/install.php \
-  --dbtype sqlite \
+  --dbtype $DB_TYPE \
+  --dbpass 'root' \
   --dbuser root \
   --dbname mw \
   --dbpath $(pwd) \


### PR DESCRIPTION
Specifically, add support for a `use_mysql` input that switches to using MySQL instead of SQLite.

SEL-1067